### PR TITLE
Add possibility to setup firebase options when initializing app

### DIFF
--- a/flask_firebase_admin/flask_firebase_admin.py
+++ b/flask_firebase_admin/flask_firebase_admin.py
@@ -57,6 +57,7 @@ class FirebaseAdmin(object):
             "FIREBASE_ADMIN_AUTHORIZATION_SCHEME",
             FIREBASE_ADMIN_AUTHORIZATION_SCHEME,
         )
+        app.config.setdefault("FIREBASE_ADMIN_OPTIONS")
         app.config.setdefault(
             "FIREBASE_ADMIN_CHECK_REVOKED", FIREBASE_ADMIN_CHECK_REVOKED
         )
@@ -65,7 +66,8 @@ class FirebaseAdmin(object):
         )
 
         cred = app.config["FIREBASE_ADMIN_CREDENTIAL"]
-        self._admin = firebase_admin.initialize_app(cred)
+        options = app.config["FIREBASE_ADMIN_OPTIONS"]
+        self._admin = firebase_admin.initialize_app(cred, options=options)
 
     @property
     def admin(self) -> firebase_admin.App:


### PR DESCRIPTION
Hello @andrewrosss ,

I'm just adding the possibility to give the library additional options when calling firebase.initialize_app, for example I use it to define the bucket default storage path.

If you'd like to merge it, would be nice :)

Thanks for the good work, the project is working nicely !

Bye